### PR TITLE
Fix jsonSubtreeCodec only serializing up to 4B numbers

### DIFF
--- a/core/ydk/src/json_subtree_codec.cpp
+++ b/core/ydk/src/json_subtree_codec.cpp
@@ -224,7 +224,7 @@ static json get_json_leaf_value(string & leaf_value)
     else {
         bool is_number = all_of(leaf_value.begin(), leaf_value.end(), ::isdigit);
         if (is_number) {
-            int jint = stoi(leaf_value);
+            long long jint = stoll(leaf_value);
             return json(jint);
         }
         else {


### PR DESCRIPTION
The JsonSubtreeCodec class failed in case it had to serialize numbers bigger than int (4 bytes). E.g. uint64 type of leaf in yang. The problem was that the class always used "stoi" function regardless of type.

Simple fix: always use "stoll" as "long long" is the biggest number used in YANG models.

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>